### PR TITLE
Fixed credit label

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,7 +118,7 @@ body {
     
     .credits {
         position: absolute;
-        bottom: 5px;
+        bottom: 1px;
         left: 5px;
         color: #A2A2A2;
         font-size: 12px;


### PR DESCRIPTION
Moved the credit label down a little to prevent it from overlapping the video player.